### PR TITLE
Handle per-platform overrides during upload

### DIFF
--- a/Editor/VRCMultiUploader.cs
+++ b/Editor/VRCMultiUploader.cs
@@ -96,7 +96,7 @@ namespace VRCMultiUploader
                     {
                         Debug.Log($"Uploading avatar: {avatarObject.name} with blueprintId: {blueprintId}");
                         VRCAvatar av = await VRCApi.GetAvatar(blueprintId);
-                        await builder.BuildAndUpload(avatarObject, av, cancellationToken: cts.Token);
+                        await builder.BuildAndUpload(avatarObject, PerPlatformOverrides.GetPlatformOverrides(avatarObject), av, cancellationToken: cts.Token);
                         success = true;
                     }
                     else


### PR DESCRIPTION
This allows you to upload all of your avatars to multiple platforms without having to switch them out.

Documentation: https://creators.vrchat.com/avatars/per-platform-avatar-overrides